### PR TITLE
Improve billing logic and add coverage

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1,0 +1,18 @@
+name: Maven Build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: Build with Maven
+        run: mvn -B clean install

--- a/pom.xml
+++ b/pom.xml
@@ -14,18 +14,6 @@
             <version>5.7.1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.5.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.22.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/com/example/geektrust/model/Coupon.java
+++ b/src/main/java/com/example/geektrust/model/Coupon.java
@@ -1,8 +1,56 @@
 package com.example.geektrust.model;
 
 public enum Coupon {
-    B4G1,
-    DEAL_G20,
-    DEAL_G5,
-    NONE;
+    B4G1 {
+        @Override
+        public boolean isApplicable(Order order, float subTotal) {
+            return order.getTotalQuantity() >= B4G1_MIN_PROGRAMS;
+        }
+
+        @Override
+        public float discountAmount(Order order, float subTotal) {
+            return order.getCheapestProgramPrice();
+        }
+    },
+    DEAL_G20 {
+        @Override
+        public boolean isApplicable(Order order, float subTotal) {
+            return order.hasCoupon(this) && subTotal >= DEAL_G20_THRESHOLD;
+        }
+
+        @Override
+        public float discountAmount(Order order, float subTotal) {
+            return subTotal * 20f / 100f;
+        }
+    },
+    DEAL_G5 {
+        @Override
+        public boolean isApplicable(Order order, float subTotal) {
+            return order.hasCoupon(this) && order.getTotalQuantity() >= DEAL_G5_MIN_PROGRAMS;
+        }
+
+        @Override
+        public float discountAmount(Order order, float subTotal) {
+            return subTotal * 5f / 100f;
+        }
+    },
+    NONE {
+        @Override
+        public boolean isApplicable(Order order, float subTotal) {
+            return false;
+        }
+
+        @Override
+        public float discountAmount(Order order, float subTotal) {
+            return 0f;
+        }
+    };
+
+    private static final float DEAL_G20_THRESHOLD = 10000f;
+    private static final int DEAL_G5_MIN_PROGRAMS = 2;
+    private static final int B4G1_MIN_PROGRAMS = 4;
+
+    public abstract boolean isApplicable(Order order, float subTotal);
+
+    public abstract float discountAmount(Order order, float subTotal);
 }

--- a/src/main/java/com/example/geektrust/model/Order.java
+++ b/src/main/java/com/example/geektrust/model/Order.java
@@ -39,4 +39,11 @@ public class Order {
     public int getTotalQuantity() {
         return items.stream().mapToInt(OrderItem::getQuantity).sum();
     }
+
+    public float getCheapestProgramPrice() {
+        return (float) items.stream()
+                .mapToDouble(i -> i.getProgram().getPrice())
+                .min()
+                .orElse(0d);
+    }
 }

--- a/src/main/java/com/example/geektrust/service/BillingService.java
+++ b/src/main/java/com/example/geektrust/service/BillingService.java
@@ -6,20 +6,17 @@ public class BillingService {
     private static final float PRO_MEMBERSHIP_FEE = 200f;
     private static final float ENROLLMENT_FEE = 500f;
     private static final float ENROLLMENT_THRESHOLD = 6666f;
-    private static final float DEAL_G20_THRESHOLD = 10000f;
-    private static final int DEAL_G5_MIN_PROGRAMS = 2;
-    private static final int B4G1_MIN_PROGRAMS = 4;
 
     public Bill generateBill(Order order) {
         float subTotal = calculateSubTotal(order);
         float proDiscount = calculateProDiscount(order);
         Coupon coupon = determineCoupon(order, subTotal);
-        float couponDiscount = calculateCouponDiscount(order, subTotal, coupon);
-        float membershipFee = order.hasProMembership() ? PRO_MEMBERSHIP_FEE : 0f;
+        float couponDiscount = coupon.discountAmount(order, subTotal);
+        float membershipFee = calculateMembershipFee(order);
 
-        float total = subTotal - proDiscount - couponDiscount + membershipFee;
-        float enrollmentFee = total < ENROLLMENT_THRESHOLD ? ENROLLMENT_FEE : 0f;
-        total += enrollmentFee;
+        float totalBeforeEnrollment = subTotal - proDiscount - couponDiscount + membershipFee;
+        float enrollmentFee = calculateEnrollmentFee(totalBeforeEnrollment);
+        float total = totalBeforeEnrollment + enrollmentFee;
 
         return new Bill(subTotal, coupon, couponDiscount, proDiscount, membershipFee, enrollmentFee, total);
     }
@@ -40,35 +37,23 @@ public class BillingService {
     }
 
     private Coupon determineCoupon(Order order, float subTotal) {
-        if (order.getTotalQuantity() >= B4G1_MIN_PROGRAMS) {
+        if (Coupon.B4G1.isApplicable(order, subTotal)) {
             return Coupon.B4G1;
         }
-        if (order.hasCoupon(Coupon.DEAL_G20) && subTotal >= DEAL_G20_THRESHOLD) {
+        if (Coupon.DEAL_G20.isApplicable(order, subTotal)) {
             return Coupon.DEAL_G20;
         }
-        if (order.hasCoupon(Coupon.DEAL_G5) && order.getTotalQuantity() >= DEAL_G5_MIN_PROGRAMS) {
+        if (Coupon.DEAL_G5.isApplicable(order, subTotal)) {
             return Coupon.DEAL_G5;
         }
         return Coupon.NONE;
     }
 
-    private float calculateCouponDiscount(Order order, float subTotal, Coupon coupon) {
-        switch (coupon) {
-            case B4G1:
-                return cheapestProgramPrice(order);
-            case DEAL_G20:
-                return subTotal * 20f / 100f;
-            case DEAL_G5:
-                return subTotal * 5f / 100f;
-            default:
-                return 0f;
-        }
+    private float calculateMembershipFee(Order order) {
+        return order.hasProMembership() ? PRO_MEMBERSHIP_FEE : 0f;
     }
 
-    private float cheapestProgramPrice(Order order) {
-        return (float) order.getItems().stream()
-                .mapToDouble(i -> i.getProgram().getPrice())
-                .min()
-                .orElse(0d);
+    private float calculateEnrollmentFee(float total) {
+        return total < ENROLLMENT_THRESHOLD ? ENROLLMENT_FEE : 0f;
     }
 }

--- a/src/test/java/com/example/geektrust/BillingServiceTest.java
+++ b/src/test/java/com/example/geektrust/BillingServiceTest.java
@@ -51,4 +51,28 @@ public class BillingServiceTest {
         assertEquals(Coupon.DEAL_G5, bill.getCoupon());
         assertEquals(5725f, bill.getTotal(), 0.001); // (5500 - 275) + 500 enrollment
     }
+
+    @Test
+    void shouldChargeMembershipFeeForProUsers() {
+        Order order = new Order();
+        order.addProgram(ProgramType.CERTIFICATION, 1);
+        order.addProMembership();
+
+        Bill bill = billingService.generateBill(order);
+
+        assertEquals(200f, bill.getMembershipFee(), 0.001);
+        assertEquals(3640f, bill.getTotal(), 0.001);
+    }
+
+    @Test
+    void shouldWaiveEnrollmentFeeWhenTotalAboveThreshold() {
+        Order order = new Order();
+        order.addProgram(ProgramType.DEGREE, 2); // 10000
+        order.addProMembership();
+        order.addCoupon("DEAL_G20");
+
+        Bill bill = billingService.generateBill(order);
+
+        assertEquals(0f, bill.getEnrollmentFee(), 0.001);
+    }
 }


### PR DESCRIPTION
## Summary
- refactor coupon handling to use enum methods
- move cheapest program logic into `Order`
- restructure billing computations for readability
- add tests for membership fee and enrollment fee

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6864d62db8ec8321b0d0dd88aa34fcf2