### PR TITLE
Fix integration tests for Java 8

### DIFF
--- a/src/test/java/com/example/geektrust/SampleIOIntegrationTest.java
+++ b/src/test/java/com/example/geektrust/SampleIOIntegrationTest.java
@@ -1,0 +1,81 @@
+package com.example.geektrust;
+
+import com.example.geektrust.command.CommandProcessor;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Integration tests that execute the application using the sample input files
+ * provided in the repository. The tests verify that the program output matches
+ * the expected results for each sample scenario.
+ */
+public class SampleIOIntegrationTest {
+
+    private String runApp(Path inputFile) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(out));
+        new CommandProcessor().run(inputFile.toString());
+        System.setOut(original);
+        return out.toString().replace("\r", "").trim();
+    }
+
+    @Test
+    void sampleInput1() throws Exception {
+        Path input = Paths.get("sample_input", "input1.txt");
+        String expected = String.join("\n",
+                "SUB_TOTAL 13000.00",
+                "COUPON_DISCOUNT B4G1 2500.00",
+                "TOTAL_PRO_DISCOUNT 0.00",
+                "PRO_MEMBERSHIP_FEE 0.00",
+                "ENROLLMENT_FEE 0.00",
+                "TOTAL 10500.00");
+        assertEquals(expected, runApp(input));
+    }
+
+    @Test
+    void sampleInput2() throws Exception {
+        Path input = Paths.get("sample_input", "input2.txt");
+        String expected = String.join("\n",
+                "SUB_TOTAL 18000.00",
+                "COUPON_DISCOUNT B4G1 2500.00",
+                "TOTAL_PRO_DISCOUNT 410.00",
+                "PRO_MEMBERSHIP_FEE 200.00",
+                "ENROLLMENT_FEE 0.00",
+                "TOTAL 15290.00");
+        assertEquals(expected, runApp(input));
+    }
+
+    @Test
+    void sampleInput3() throws Exception {
+        Path input = Paths.get("sample_input", "input3.txt");
+        String expected = String.join("\n",
+                "SUB_TOTAL 5500.00",
+                "COUPON_DISCOUNT NONE 0.00",
+                "TOTAL_PRO_DISCOUNT 85.00",
+                "PRO_MEMBERSHIP_FEE 200.00",
+                "ENROLLMENT_FEE 500.00",
+                "TOTAL 6115.00");
+        assertEquals(expected, runApp(input));
+    }
+
+    @Test
+    void sampleInput4() throws Exception {
+        Path input = Paths.get("sample_input", "input4.txt");
+        String expected = String.join("\n",
+                "SUB_TOTAL 8500.00",
+                "COUPON_DISCOUNT DEAL_G5 425.00",
+                "TOTAL_PRO_DISCOUNT 145.00",
+                "PRO_MEMBERSHIP_FEE 200.00",
+                "ENROLLMENT_FEE 0.00",
+                "TOTAL 8130.00");
+        assertEquals(expected, runApp(input));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add new integration tests that use sample input files
- avoid `Path.of()` by using `Paths.get()` so tests can compile on Java 8

## Testing
- `javac -source 8 -target 8 -d /tmp/classes $(find src/main/java -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_6864f5fe260883218b0e12f902f47731